### PR TITLE
Add formatter option and use it for output

### DIFF
--- a/lib/guard/eslint.rb
+++ b/lib/guard/eslint.rb
@@ -21,6 +21,7 @@ module Guard
         keep_failed:  false,
         notification: :failed,
         cli: nil,
+        formatter: nil,
         hide_stdout: false
       }.merge(options)
 

--- a/lib/guard/eslint/runner.rb
+++ b/lib/guard/eslint/runner.rb
@@ -12,7 +12,7 @@ module Guard
       end
 
       def run(paths = [])
-        command = build_command(paths)
+        command = command_for_check(paths)
         passed = system(*command)
         case @options[:notification]
         when :failed
@@ -21,28 +21,31 @@ module Guard
           notify(passed)
         end
 
-        show_output(paths)
+        run_for_output(paths)
 
         passed
       end
 
-      def show_output(paths)
+      ##
+      # Once eslint reports a failure, we have to run it again to show the results using the
+      # formatter that it uses for output.
+      # This because eslint doesn't support multiple formatters during the same run.
+      def run_for_output(paths)
         command = ['eslint']
 
-        command.concat(['**/*.js', '**/*.es6']) if paths.empty?
-
         command.concat(args_specified_by_user)
+        command.concat(['-f', @options[:formatter]]) if @options[:formatter]
+        command.concat(['**/*.js', '**/*.es6']) if paths.empty?
         command.concat(paths)
         system(*command)
       end
 
-      def build_command(paths)
+      def command_for_check(paths)
         command = ['eslint']
 
-        command.concat(['**/*.js', '**/*.es6']) if paths.empty?
-
-        command.concat(['-f', 'json', '-o', json_file_path])
         command.concat(args_specified_by_user)
+        command.concat(['-f', 'json', '-o', json_file_path])
+        command.concat(['**/*.js', '**/*.es6']) if paths.empty?
         command.concat(paths)
       end
 


### PR DESCRIPTION
The guard runs `eslint` telling it to use the json formatter, and then after parsing that output it runs `eslint` again. Modifying the `cli` option to specify a formatter wouldn't work because it would interfere with the first step.

I added a `formatter` option and use it when `eslint` is being invoked the second time.
