### PR TITLE
Clean up options and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ cli: nil                               # Additional command-line options to pass
 formatter: nil                         # Formatter to use for output to the console.
 command: 'eslint'                      # Specify a custom path to the eslint command.
 default_paths: ['**/*.js', '**/*.es6'] # The default paths that will be used for "all_on_start".
+no_for_zero: false                     # When displaying "0" for results, use the word "no" instead.
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Guard::Eslint
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/guard/eslint`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Guard::Eslint allows you to automatically run eslint when you change a Javascript/ES6 file.
+This is best when run after your Javascript tests pass.
 
 ## Installation
 
@@ -22,15 +21,38 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+Please read [Guard usage doc](https://github.com/guard/guard#readme).
 
-## Development
+## Guardfile
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+For a typical Rails app with webpack:
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+``` ruby
+guard :eslint, formatter: 'codeframe' do
+  watch(%r{^spec/javascript/.+\.(js|es6)$})
+end
+```
+
+### List of available options:
+
+``` ruby
+all_on_start: true                     # Run all specs after changed specs pass.
+keep_failed: false                     # Keep failed files until they pass (add them to new ones)
+notification: :failed                  # Display notification when eslint reports an issue.
+                                       # If you want to always notify, set to true.
+cli: nil                               # Additional command-line options to pass to eslint.
+                                       # Don't use the '-f' or '--format' option here.
+formatter: nil                         # Formatter to use for output to the console.
+command: 'eslint'                      # Specify a custom path to the eslint command.
+default_paths: ['**/*.js', '**/*.es6'] # The default paths that will be used for "all_on_start".
+```
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/guard-eslint.
+Bug reports and pull requests are welcome on GitHub at https://github.com/RobinDaugherty/guard-eslint.
 
+* Please create a topic branch for every separate change you make.
+* Make sure your patches are well-tested.
+* Update the README to reflect your changes.
+* Please **do not change** the version number.
+* Open a pull request. 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For a typical Rails app with webpack:
 
 ``` ruby
 guard :eslint, formatter: 'codeframe' do
+  watch(%r{^app/javascript/.+\.(js|es6)$})
   watch(%r{^spec/javascript/.+\.(js|es6)$})
 end
 ```

--- a/lib/guard/eslint.rb
+++ b/lib/guard/eslint.rb
@@ -23,6 +23,7 @@ module Guard
         cli: nil,
         formatter: nil,
         hide_stdout: false,
+        command: 'eslint',
         default_paths: ['**/*.js', '**/*.es6'],
       }.merge(options)
 

--- a/lib/guard/eslint.rb
+++ b/lib/guard/eslint.rb
@@ -22,7 +22,8 @@ module Guard
         notification: :failed,
         cli: nil,
         formatter: nil,
-        hide_stdout: false
+        hide_stdout: false,
+        default_paths: ['**/*.js', '**/*.es6'],
       }.merge(options)
 
       @failed_paths = []

--- a/lib/guard/eslint.rb
+++ b/lib/guard/eslint.rb
@@ -24,6 +24,7 @@ module Guard
         formatter: nil,
         command: 'eslint',
         default_paths: ['**/*.js', '**/*.es6'],
+        no_for_zero: true,
       }.merge(options)
 
       @failed_paths = []

--- a/lib/guard/eslint.rb
+++ b/lib/guard/eslint.rb
@@ -17,12 +17,11 @@ module Guard
       super
 
       @options = {
-        all_on_start: true,
-        keep_failed:  false,
+        all_on_start: false,
+        keep_failed: false,
         notification: :failed,
         cli: nil,
         formatter: nil,
-        hide_stdout: false,
         command: 'eslint',
         default_paths: ['**/*.js', '**/*.es6'],
       }.merge(options)

--- a/lib/guard/eslint/runner.rb
+++ b/lib/guard/eslint/runner.rb
@@ -11,10 +11,12 @@ module Guard
         @options = options
       end
 
+      attr_reader :options
+
       def run(paths = [])
         command = command_for_check(paths)
         passed = system(*command)
-        case @options[:notification]
+        case options[:notification]
         when :failed
           notify(passed) unless passed
         when true
@@ -34,8 +36,8 @@ module Guard
         command = ['eslint']
 
         command.concat(args_specified_by_user)
-        command.concat(['-f', @options[:formatter]]) if @options[:formatter]
         command.concat(['**/*.js', '**/*.es6']) if paths.empty?
+        command.concat(['-f', options[:formatter]]) if options[:formatter]
         command.concat(paths)
         system(*command)
       end
@@ -51,7 +53,7 @@ module Guard
 
       def args_specified_by_user
         @args_specified_by_user ||= begin
-          args = @options[:cli]
+          args = options[:cli]
           case args
           when Array    then args
           when String   then args.shellsplit

--- a/lib/guard/eslint/runner.rb
+++ b/lib/guard/eslint/runner.rb
@@ -13,7 +13,9 @@ module Guard
 
       attr_reader :options
 
-      def run(paths = [])
+      def run(paths)
+        paths = options[:default_paths] unless paths
+
         command = command_for_check(paths)
         passed = system(*command)
         case options[:notification]
@@ -36,7 +38,6 @@ module Guard
         command = ['eslint']
 
         command.concat(args_specified_by_user)
-        command.concat(['**/*.js', '**/*.es6']) if paths.empty?
         command.concat(['-f', options[:formatter]]) if options[:formatter]
         command.concat(paths)
         system(*command)
@@ -47,7 +48,6 @@ module Guard
 
         command.concat(args_specified_by_user)
         command.concat(['-f', 'json', '-o', json_file_path])
-        command.concat(['**/*.js', '**/*.es6']) if paths.empty?
         command.concat(paths)
       end
 

--- a/lib/guard/eslint/runner.rb
+++ b/lib/guard/eslint/runner.rb
@@ -112,7 +112,7 @@ module Guard
         result.reject { |f| f[:messages].empty? }.map { |f| f[:filePath] }
       end
 
-      def pluralize(number, thing, options = {})
+      def pluralize(number, thing)
         text = ''
 
         if number == 0 && options[:no_for_zero]

--- a/lib/guard/eslint/runner.rb
+++ b/lib/guard/eslint/runner.rb
@@ -35,7 +35,7 @@ module Guard
       # formatter that it uses for output.
       # This because eslint doesn't support multiple formatters during the same run.
       def run_for_output(paths)
-        command = ['eslint']
+        command = [options[:command]]
 
         command.concat(args_specified_by_user)
         command.concat(['-f', options[:formatter]]) if options[:formatter]
@@ -44,7 +44,7 @@ module Guard
       end
 
       def command_for_check(paths)
-        command = ['eslint']
+        command = [options[:command]]
 
         command.concat(args_specified_by_user)
         command.concat(['-f', 'json', '-o', json_file_path])


### PR DESCRIPTION
- Add `default_paths` option instead of hard-coding the defaults.
- Add `command` option instead of hard-coded command.
- Change default for `all_on_start` to false.
- Document and actually use the `no_for_zero` option.
- Update the readme to contain actual documentation, including the available options.